### PR TITLE
サイトアクセス時にモーダルが開く問題を修正

### DIFF
--- a/js/component.js
+++ b/js/component.js
@@ -71,15 +71,6 @@ $(window).scroll(function () {
 
 // モーダル初回表示処理
 $(function () {
-  var access = $.cookie('access');
-  var flag = !access;
-  if (flag) {
-    $.cookie('access', false);
-
-    setTimeout(function () {
-      $(".js-modal-open").modaal('open');
-    }, 500);
-  }
 
   $(".js-modal-open").modaal({
     overlay_close: true,


### PR DESCRIPTION
var access = $.cookie('access');
  var flag = !access;
  if (flag) {
    $.cookie('access', false);

    setTimeout(function () {
      $(".js-modal-open").modaal('open');
    }, 500);
  }

初めてアクセスする（キャッシュを持っていない）ときに全てのモーダルを開く処理になっていた。